### PR TITLE
update build_latest to use node version 18.15.0

### DIFF
--- a/build_latest.sh
+++ b/build_latest.sh
@@ -26,7 +26,7 @@ sudo apt-get install git-lfs -y
 # Install NVM (Node Version Manager) required node.js
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
 source $HOME/.nvm/nvm.sh
-nvm install v14.16.0
+nvm install v18.15.0
 npm install -g npm
 npm update -g
 


### PR DESCRIPTION
Hello @mosssahel the latest version of Signal requires node 18.15.0 to be build.
I am updating the script to use this new version.

Thanks a lot for your work on this project <3 